### PR TITLE
Add simple cookie clicker mini-game

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,176 @@
 #root {
-  max-width: 1280px;
+  max-width: 960px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.app-container {
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(6px);
+  border-radius: 32px;
+  box-shadow: 0 32px 80px rgba(240, 148, 80, 0.35);
+  padding: 3rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+}
+
+header {
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+h1 {
+  margin: 0;
+  font-size: clamp(2.5rem, 4vw, 3.2rem);
+  color: #70371c;
+  letter-spacing: 0.06em;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.tagline {
+  margin: 0.75rem 0 0;
+  color: #9a5a2d;
+  font-size: 1.05rem;
+}
+
+.scoreboard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  width: 100%;
+}
+
+.scoreboard > div {
+  background: linear-gradient(135deg, rgba(255, 241, 218, 0.9), rgba(255, 226, 187, 0.9));
+  border-radius: 18px;
+  padding: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 188, 128, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.score-label {
+  font-size: 0.95rem;
+  color: #b0743a;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.score-value {
+  font-size: 1.9rem;
+  color: #5a2a12;
+  font-weight: 700;
+}
+
+.cookie-button {
+  width: clamp(200px, 30vw, 260px);
+  height: clamp(200px, 30vw, 260px);
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: radial-gradient(circle at 30% 30%, #ffd6a5, #f4a261 55%, #d47f2f 85%);
+  box-shadow: 0 22px 40px rgba(178, 91, 23, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: clamp(4rem, 8vw, 5.5rem);
+  line-height: 1;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.cookie-button:hover {
+  transform: translateY(-4px) scale(1.02);
+  box-shadow: 0 28px 50px rgba(178, 91, 23, 0.4);
+}
+
+.cookie-button:active {
+  transform: scale(0.96);
+  box-shadow: 0 10px 20px rgba(178, 91, 23, 0.3);
+}
+
+.upgrades {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.upgrade-card {
+  background: rgba(255, 246, 230, 0.9);
+  border-radius: 22px;
+  padding: 1.75rem;
+  box-shadow: 0 18px 45px rgba(255, 199, 141, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  color: #5a2a12;
+}
+
+.upgrade-card h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.upgrade-card p {
+  margin: 0;
+  color: #7f4521;
+  line-height: 1.5;
+}
+
+.upgrade-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.cost {
+  font-weight: 700;
+  color: #c26f2b;
+}
+
+.upgrade-footer button {
+  border-radius: 999px;
+  border: none;
+  padding: 0.6rem 1.4rem;
+  background: linear-gradient(135deg, #f7ad6b, #f0803c);
+  color: #fff8ef;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, filter 120ms ease;
+}
+
+.upgrade-footer button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(240, 146, 78, 0.35);
+}
+
+.upgrade-footer button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 5px 12px rgba(240, 146, 78, 0.4);
+}
+
+.upgrade-footer button:disabled {
+  cursor: not-allowed;
+  filter: saturate(0.5);
+  opacity: 0.6;
+}
+
+@media (max-width: 600px) {
+  .app-container {
+    padding: 2.5rem 1.75rem;
+    gap: 2rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .upgrade-footer {
+    flex-direction: column;
+    align-items: flex-start;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .upgrade-footer button {
+    width: 100%;
+    text-align: center;
   }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,112 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useMemo, useState } from 'react'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [cookies, setCookies] = useState(0)
+  const [clickPower, setClickPower] = useState(1)
+  const [clickUpgradeCost, setClickUpgradeCost] = useState(10)
+  const [autoClickers, setAutoClickers] = useState(0)
+  const [autoClickerCost, setAutoClickerCost] = useState(25)
+
+  useEffect(() => {
+    if (autoClickers === 0) return
+
+    const interval = window.setInterval(() => {
+      setCookies((prev) => prev + autoClickers)
+    }, 1000)
+
+    return () => window.clearInterval(interval)
+  }, [autoClickers])
+
+  const cookiesPerSecond = useMemo(() => autoClickers, [autoClickers])
+
+  const handleCookieClick = () => {
+    setCookies((prev) => prev + clickPower)
+  }
+
+  const handleBuyClickUpgrade = () => {
+    if (cookies < clickUpgradeCost) return
+
+    setCookies((prev) => prev - clickUpgradeCost)
+    setClickPower((prev) => prev + 1)
+    setClickUpgradeCost((prev) => Math.ceil(prev * 1.5))
+  }
+
+  const handleBuyAutoClicker = () => {
+    if (cookies < autoClickerCost) return
+
+    setCookies((prev) => prev - autoClickerCost)
+    setAutoClickers((prev) => prev + 1)
+    setAutoClickerCost((prev) => Math.ceil(prev * 1.6))
+  }
+
+  const formatNumber = (value: number) => value.toLocaleString()
 
   return (
-    <>
-      <div className="flex justify-center items-center">
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1 className={"text-3xl"}>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
+    <div className="app-container">
+      <header>
+        <h1>Cookie Craze</h1>
+        <p className="tagline">
+          點擊超大餅乾、購買升級，打造屬於你的小小烘焙王國！
         </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      </header>
+
+      <section className="scoreboard" aria-live="polite">
+        <div>
+          <span className="score-label">餅乾</span>
+          <span className="score-value">{formatNumber(cookies)}</span>
+        </div>
+        <div>
+          <span className="score-label">每次點擊</span>
+          <span className="score-value">+{formatNumber(clickPower)}</span>
+        </div>
+        <div>
+          <span className="score-label">每秒產量</span>
+          <span className="score-value">+{formatNumber(cookiesPerSecond)}</span>
+        </div>
+      </section>
+
+      <button
+        type="button"
+        className="cookie-button"
+        onClick={handleCookieClick}
+        aria-label="點擊餅乾獲得分數"
+      >
+        🍪
+      </button>
+
+      <section className="upgrades">
+        <article className="upgrade-card">
+          <h2>豪華餅乾模具</h2>
+          <p>讓每次點擊多出一塊香噴噴的餅乾。</p>
+          <div className="upgrade-footer">
+            <span className="cost">花費：{formatNumber(clickUpgradeCost)}</span>
+            <button
+              type="button"
+              onClick={handleBuyClickUpgrade}
+              disabled={cookies < clickUpgradeCost}
+            >
+              升級點擊力
+            </button>
+          </div>
+        </article>
+
+        <article className="upgrade-card">
+          <h2>自動烘焙助手</h2>
+          <p>雇用小幫手幫你 24 小時烘烤餅乾！</p>
+          <div className="upgrade-footer">
+            <span className="cost">花費：{formatNumber(autoClickerCost)}</span>
+            <button
+              type="button"
+              onClick={handleBuyAutoClicker}
+              disabled={cookies < autoClickerCost}
+            >
+              增聘助手 (+1/秒)
+            </button>
+          </div>
+        </article>
+      </section>
+    </div>
   )
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,16 +1,16 @@
+@import url('https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Baloo 2', 'Noto Sans TC', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
   line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  font-weight: 500;
+  color: #4a2511;
+  background-color: #ffedd8;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -18,55 +18,25 @@
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: inherit;
+  text-decoration: none;
 }
+
 a:hover {
-  color: #535bf2;
+  text-decoration: underline;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  background: radial-gradient(circle at top, #ffe5c4 0%, #ffd2a1 45%, #ffb785 100%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1.5rem;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- replace the default Vite counter screen with a themed Cookie Craze clicker mini-game
- add interactive upgrades for stronger clicks and passive bakers with refreshed styling
- refresh global styles to match the playful dessert atmosphere and font

## Testing
- yarn test --watchAll=false *(fails: script not found in package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68e3b133610c832ea662584cb5b07c6e